### PR TITLE
Makes `import plyj`'s result more natural.

### DIFF
--- a/plyj/__init__.py
+++ b/plyj/__init__.py
@@ -1,0 +1,3 @@
+# Import stuff from the pacakge to allow access using import
+from . import models
+from . import parser


### PR DESCRIPTION
The added imports make parser and model available from `import plyj` and use `plyj.parser` without having to import it from specifically. It is only more natural that import behaves this way.