### PR TITLE
fix 'line comment at last line' parsing error

### DIFF
--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -43,9 +43,7 @@ class MyLexer(object):
     t_CHAR_LITERAL = r'\'([^\\\n]|(\\.))*?\''
     t_STRING_LITERAL = r'\"([^\\\n]|(\\.))*?\"'
 
-    def t_LINE_COMMENT(self, t):
-        r'//.*?\n'
-        t.lexer.lineno += 1
+    t_ignore_LINE_COMMENT = r'//[^\\\n].*'
 
     def t_BLOCK_COMMENT(self, t):
         r'/\*(.|\n)*?\*/'

--- a/test/compilation_unit.py
+++ b/test/compilation_unit.py
@@ -86,6 +86,12 @@ class CompilationUnitTest(unittest.TestCase):
             members=[model.AnnotationMember(name=model.Name('key'),
                                             value=model.Literal('1'))])])
 
+    def test_line_comment(self):
+        m = self.parser.parse_string('''
+        class Foo {}
+        // line comment at last line''');
+        self._assert_declaration(m, 'Foo') 
+
     def _assert_declaration(self, compilation_unit, name, index=0, type=model.ClassDeclaration):
         self.assertIsInstance(compilation_unit, model.CompilationUnit)
         self.assertTrue(len(compilation_unit.type_declarations) >= index + 1)


### PR DESCRIPTION
If input ends with a line comment without new line,
parsing fails.
