### PR TITLE
fix abstract method parse tree

### DIFF
--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -1531,10 +1531,7 @@ class ClassParser(object):
         '''method_declaration : abstract_method_declaration
                               | method_header method_body'''
         if len(p) == 2:
-            p[0] = MethodDeclaration(p[1]['name'], abstract=True, parameters=p[1]['parameters'],
-                                     extended_dims=p[1]['extended_dims'], type_parameters=p[1]['type_parameters'],
-                                     return_type=p[1]['type'], modifiers=p[1]['modifiers'],
-                                     throws=p[1]['throws'])
+            p[0] = p[1]
         else:
             p[0] = MethodDeclaration(p[1]['name'], parameters=p[1]['parameters'],
                                      extended_dims=p[1]['extended_dims'], type_parameters=p[1]['type_parameters'],
@@ -1543,8 +1540,11 @@ class ClassParser(object):
 
     def p_abstract_method_declaration(self, p):
         '''abstract_method_declaration : method_header ';' '''
-        p[0] = p[1]
-
+        p[0] = MethodDeclaration(p[1]['name'], abstract=True, parameters=p[1]['parameters'],
+                                 extended_dims=p[1]['extended_dims'], type_parameters=p[1]['type_parameters'],
+                                 return_type=p[1]['type'], modifiers=p[1]['modifiers'],
+                                 throws=p[1]['throws'])
+ 
     def p_method_header(self, p):
         '''method_header : method_header_name formal_parameter_list_opt ')' method_header_extended_dims method_header_throws_clause_opt'''
         p[1]['parameters'] = p[2]

--- a/test/type_declaration.py
+++ b/test/type_declaration.py
@@ -1,0 +1,48 @@
+import unittest
+
+import plyj.parser as plyj
+import plyj.model as model
+from plyj.model import *
+
+class TypeDeclarationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = plyj.Parser()
+
+    def test_class_method(self):
+        m = self.parser.parse_string('''
+        class Foo {
+          void foo() {}
+        }
+        ''')
+        cls = self._assert_declaration(m, 'Foo')
+        self.assertEquals(cls.body, [MethodDeclaration('foo', body=[])])
+
+    def test_interface_method(self):
+        m = self.parser.parse_string('''
+        interface Foo {
+          void foo();
+        }
+        ''')
+        cls = self._assert_declaration(m, 'Foo', type=model.InterfaceDeclaration)
+        self.assertEquals(cls.body, [MethodDeclaration('foo', abstract=True)])
+
+    def test_class_abstract_method(self):
+        m = self.parser.parse_string('''
+        abstract class Foo {
+          abstract void foo();
+        }
+        ''')
+        cls = self._assert_declaration(m, 'Foo')
+        self.assertEquals(cls.body, [MethodDeclaration('foo', modifiers=['abstract'], abstract=True)])
+
+    def _assert_declaration(self, compilation_unit, name, index=0, type=model.ClassDeclaration):
+        self.assertIsInstance(compilation_unit, model.CompilationUnit)
+        self.assertTrue(len(compilation_unit.type_declarations) >= index + 1)
+
+        decl = compilation_unit.type_declarations[index]
+        self.assertIsInstance(decl, type)
+
+        self.assertEqual(decl.name, name)
+
+        return decl


### PR DESCRIPTION
interfaces' methods should be parsed as
MethodDeclaration.
