### PR TITLE
Fix a regular expression for a line comment

### DIFF
--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -43,7 +43,7 @@ class MyLexer(object):
     t_CHAR_LITERAL = r'\'([^\\\n]|(\\.))*?\''
     t_STRING_LITERAL = r'\"([^\\\n]|(\\.))*?\"'
 
-    t_ignore_LINE_COMMENT = r'//[^\\\n].*'
+    t_ignore_LINE_COMMENT = '//.*'
 
     def t_BLOCK_COMMENT(self, t):
         r'/\*(.|\n)*?\*/'

--- a/test/compilation_unit.py
+++ b/test/compilation_unit.py
@@ -87,8 +87,10 @@ class CompilationUnitTest(unittest.TestCase):
                                             value=model.Literal('1'))])])
 
     def test_line_comment(self):
-        m = self.parser.parse_string('''
+        m = self.parser.parse_string(r'''
         class Foo {}
+        //
+        //\
         // line comment at last line''');
         self._assert_declaration(m, 'Foo') 
 


### PR DESCRIPTION
The previous regular expression for a line comment requires that `//` should be immediately followed by a character other than the backslash or newline character. So it did not allow 1) a line comment whose whole line just consists of `//` or 2) a line comment where `//` is immediately followed by the backslash character.
