### PR TITLE
fix issue#20: A Crash Bug in TestVisitor testcase

### DIFF
--- a/plyj/model.py
+++ b/plyj/model.py
@@ -192,8 +192,9 @@ class MethodDeclaration(SourceElement):
 
     def accept(self, visitor):
         if visitor.visit_MethodDeclaration(self):
-            for e in self.body:
-                e.accept(visitor)
+            if not self.body == None:
+                for e in self.body:
+                    e.accept(visitor)
 
 
 class FormalParameter(SourceElement):


### PR DESCRIPTION
Interface declare will cause this bug.

```
Traceback (most recent call last):
  File "testVisitor.py", line 74, in <module>
    tree.accept(MyVisitor())
  File "/Users/sim/github/TAG_obfuscate/model.py", line 53, in accept
    type_decl.accept(visitor)
  File "/Users/sim/github/TAG_obfuscate/model.py", line 106, in accept
    decl.accept(visitor)
  File "/Users/sim/github/TAG_obfuscate/model.py", line 268, in accept
    decl.accept(visitor)
  File "/Users/sim/github/TAG_obfuscate/model.py", line 195, in accept
    for e in self.body:
TypeError: 'NoneType' object is not iterable
```
