### PR TITLE
BUGFIX: Added type check to model when accepting visitors on binary expressions

### DIFF
--- a/plyj/model.py
+++ b/plyj/model.py
@@ -459,8 +459,10 @@ class BinaryExpression(Expression):
 
     def accept(self, visitor):
         if visitor.visit_BinaryExpression(self):
-            self.lhs.accept(visitor)
-            self.rhs.accept(visitor)
+            if type(self.lhs) is not str:
+                self.lhs.accept(visitor)
+            if type(self.rhs) is not str:
+                self.rhs.accept(visitor)
 
 
 class Assignment(BinaryExpression):


### PR DESCRIPTION
@musiKk I would like to contribute the following fix:

Adding a visitor to binary expressions whereby the expression's right hand "this" would throw an error. I fixed it by applying a type-check. i.e. changed model.py from:
 def accept(self, visitor):
        if visitor.visit_BinaryExpression(self):
             self.lhs.accept(visitor)
             self.rhs.accept(visitor)
to:
 def accept(self, visitor):
        if visitor.visit_BinaryExpression(self):
            if type(self.lhs) is not str:
                self.lhs.accept(visitor)
            if type(self.rhs) is not str:
                self.rhs.accept(visitor)

Example input that will reproduce the error:

public class FooBar {

```
public static FooBar instance;

public FooBar() {
    instance = this;
}
```

}
