### PR TITLE
Add ExpressionStatement class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/*
 *.egg-info
 
 *.py[co]

--- a/plyj/model.py
+++ b/plyj/model.py
@@ -780,6 +780,13 @@ class Name(SourceElement):
             self.value = self.value + '.' + name
 
 
+class ExpressionStatement(Statement):
+    def __init__(self, expression):
+        super(ExpressionStatement, self).__init__()
+        self._fields = ['expression']
+        self.expression = expression
+
+
 class Visitor(object):
 
     def __init__(self, verbose=False):

--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -560,7 +560,10 @@ class StatementParser(object):
     def p_expression_statement(self, p):
         '''expression_statement : statement_expression ';'
                                 | explicit_constructor_invocation'''
-        p[0] = ExpressionStatement(p[1])
+        if isinstance(p[1], ConstructorInvocation):
+            p[0] = p[1]
+        else:
+            p[0] = ExpressionStatement(p[1])
 
     def p_statement_expression(self, p):
         '''statement_expression : assignment

--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -560,7 +560,7 @@ class StatementParser(object):
     def p_expression_statement(self, p):
         '''expression_statement : statement_expression ';'
                                 | explicit_constructor_invocation'''
-        p[0] = p[1]
+        p[0] = ExpressionStatement(p[1])
 
     def p_statement_expression(self, p):
         '''statement_expression : assignment

--- a/test/statements.py
+++ b/test/statements.py
@@ -122,19 +122,16 @@ class StatementTest(unittest.TestCase):
         footype = model.Type(model.Name('Foo'))
         bartype = model.Type(model.Name('Bar'))
         for call in ['super', 'this']:
-            self.assert_stmt('{}();'.format(call), model.ExpressionStatement(model.ConstructorInvocation(call)))
-            self.assert_stmt('{}(1);'.format(call),
-                             model.ExpressionStatement(model.ConstructorInvocation(call, arguments=[one])))
+            self.assert_stmt('{}();'.format(call), model.ConstructorInvocation(call))
+            self.assert_stmt('{}(1);'.format(call), model.ConstructorInvocation(call, arguments=[one]))
             self.assert_stmt('{}(1, foo, "bar");'.format(call),
-                             model.ExpressionStatement(
-                                 model.ConstructorInvocation(call, arguments=[one, foo, model.Literal('"bar"')])))
+                             model.ConstructorInvocation(call, arguments=[one, foo, model.Literal('"bar"')]))
             self.assert_stmt('<Foo> {}();'.format(call),
-                             model.ExpressionStatement(model.ConstructorInvocation(call, type_arguments=[footype])))
+                             model.ConstructorInvocation(call, type_arguments=[footype]))
             self.assert_stmt('Foo.{}();'.format(call),
-                             model.ExpressionStatement(model.ConstructorInvocation(call, target=model.Name('Foo'))))
+                             model.ConstructorInvocation(call, target=model.Name('Foo')))
             self.assert_stmt('Foo.<Bar> {}();'.format(call),
-                             model.ExpressionStatement(
-                                 model.ConstructorInvocation(call, type_arguments=[bartype], target=model.Name('Foo'))))
+                             model.ConstructorInvocation(call, type_arguments=[bartype], target=model.Name('Foo')))
 
     def test_if(self):
         self.assert_stmt('if(foo) return;', model.IfThenElse(foo, if_true=model.Return()))

--- a/test/statements.py
+++ b/test/statements.py
@@ -122,16 +122,19 @@ class StatementTest(unittest.TestCase):
         footype = model.Type(model.Name('Foo'))
         bartype = model.Type(model.Name('Bar'))
         for call in ['super', 'this']:
-            self.assert_stmt('{}();'.format(call), model.ConstructorInvocation(call))
-            self.assert_stmt('{}(1);'.format(call), model.ConstructorInvocation(call, arguments=[one]))
+            self.assert_stmt('{}();'.format(call), model.ExpressionStatement(model.ConstructorInvocation(call)))
+            self.assert_stmt('{}(1);'.format(call),
+                             model.ExpressionStatement(model.ConstructorInvocation(call, arguments=[one])))
             self.assert_stmt('{}(1, foo, "bar");'.format(call),
-                             model.ConstructorInvocation(call, arguments=[one, foo, model.Literal('"bar"')]))
+                             model.ExpressionStatement(
+                                 model.ConstructorInvocation(call, arguments=[one, foo, model.Literal('"bar"')])))
             self.assert_stmt('<Foo> {}();'.format(call),
-                             model.ConstructorInvocation(call, type_arguments=[footype]))
+                             model.ExpressionStatement(model.ConstructorInvocation(call, type_arguments=[footype])))
             self.assert_stmt('Foo.{}();'.format(call),
-                             model.ConstructorInvocation(call, target=model.Name('Foo')))
+                             model.ExpressionStatement(model.ConstructorInvocation(call, target=model.Name('Foo'))))
             self.assert_stmt('Foo.<Bar> {}();'.format(call),
-                             model.ConstructorInvocation(call, type_arguments=[bartype], target=model.Name('Foo')))
+                             model.ExpressionStatement(
+                                 model.ConstructorInvocation(call, type_arguments=[bartype], target=model.Name('Foo'))))
 
     def test_if(self):
         self.assert_stmt('if(foo) return;', model.IfThenElse(foo, if_true=model.Return()))


### PR DESCRIPTION
It's better to treat expression_statements differently than simple expressions, because statements are often handled differently than expressions, e.g., in code formatting/printing. So I implemented ExpressionStatement inheriting from Statement to wrap standalone expressions.

@musiKk Please review.