### PR TITLE
made parse_file a bit faster

### DIFF
--- a/plyj/parser.py
+++ b/plyj/parser.py
@@ -2030,9 +2030,7 @@ class Parser(object):
     def parse_file(self, _file, debug=0):
         if type(_file) == str:
             _file = open(_file)
-        content = ''
-        for line in _file:
-            content += line
+        content = _file.read()
         return self.parse_string(content, debug=debug)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I changed the parse_file function to read the file in one go instead of line-by-line. this prevents a lot of string concatenation which is slow in python.

as an added bonus: it's more readable now too.